### PR TITLE
Created stable vars for hashmaps and tokenPk and changed name symbol and query methods

### DIFF
--- a/src/DIP721/DIP721.mo
+++ b/src/DIP721/DIP721.mo
@@ -9,7 +9,7 @@ import Iter "mo:base/Iter";
 import T "dip721_types";
 
 actor class DRC721(_name : Text, _symbol : Text) {
-    private var tokenPk : Nat = 0;
+    private stable var tokenPk : Nat = 0;
 
     private stable var ownersEntries : [(T.TokenId, Principal)] = [];
     private stable var balancesEntries : [(Principal, Nat)] = [];


### PR DESCRIPTION
The HashMaps for owners, balances, tokenApprovals, operatorApprovals and tokenPk were not set as stable so those values would have been lost during a canister upgrade. I also changed the symbol and name functions to be query methods since they do not rely on consensus. I also changed  operatorApprovals from a HashMap of HashMaps to a HashMap of arrays since HashMaps are compatible with stable vars.